### PR TITLE
removed deprecated template_file in favor of templatefile function

### DIFF
--- a/real/infra/appliance/main.tf
+++ b/real/infra/appliance/main.tf
@@ -13,7 +13,9 @@ resource "aws_instance" "main" {
   key_name = var.key_name
   vpc_security_group_ids = var.security_group_ids
   subnet_id = var.subnet_id
-  user_data = data.template_file.main.rendered
+  user_data = templatefile("${path.module}/cloudinit.yaml", {
+    hostname = "${ var.name }.${ var.private_domain_name }"
+  })
   root_block_device {
     volume_size = var.volume_size
   }
@@ -23,12 +25,5 @@ resource "aws_instance" "main" {
   }
   # Making this explicit actually introduces a bug, because by default no public IP is assigned, but for a public endpoint this will *become* true, so every subsequent apply run will recreate all public instances.
   # associate_public_ip_address = false # making it explicit
-}
-
-data "template_file" "main" {
-    template = "${ file("${path.module}/cloudinit.yaml") }"
-    vars = {
-        hostname = "${ var.name }.${ var.private_domain_name }"
-    }
 }
 


### PR DESCRIPTION
Tested it (destroyed everything, recreated environment, logged into the machines) and it works as expected.

Short version?
The `template_file` data provider was deprecated some time ago. And now this code crashes in newer terraform unless the changes in this PR are merged.
See: https://github.com/hashicorp/terraform-provider-template/issues/85

Longer version?
Since I upgraded terraform I got this error:

```
Error: Incompatible provider version
│ 
│ Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a
│ package available for your current platform, darwin_arm64.
```

...which led me to this thread:
https://discuss.hashicorp.com/t/template-v2-2-0-does-not-have-a-package-available-mac-m1/35099

Wherein someone said:

> The Template provider was deprecated and archived before the existence of M1 (darwin_arm64) releases.
>
> The closing issue in the repository has examples of the replacement functionality in Terraform 0.12 and later: [hashicorp/terraform-provider-template: Issue #85](https://github.com/hashicorp/terraform-provider-template/issues/85).