### PR TITLE
Switched from x86_64 -> arm64 because cheaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 Where I keep terraform infrastructure layouts.
 
 There's only one terraform layout in here at the moment.
-It's a toy environment with two AWS EC2 instances:
+It's a toy ARM (`arm64`) environment with two AWS EC2 instances:
 
-1. SSH gateway host (`gw`) -- This is the only one with a public IP address. You SSH into this host, and from there you can SSH into any other host in the environment. Size `t3.micro`.
-2. Monitoring host (`monitor`) -- This one's beefier, because it's meant to run an Elastic / ELK monitoring stack, and I chose the smallest host that would be able to install + run those components. Size `t3a.medium`.
+1. SSH gateway host (`gw`) -- This is the only one with a public IP address. You SSH into this host, and from there you can SSH into any other host in the environment. Size `t4g.nano`.
+2. Monitoring host (`monitor`) -- This one's beefier, because it's meant to run an Elastic / ELK monitoring stack, and I chose the smallest host that would be able to install + run those components. Size `t4g.medium`.
 
 ![Architecture diagram](/arch_diagram.svg)
 
 (Diagram created using [diagrams.net](https://diagrams.net).)
 
-Running this on the west coast runs ~$70 / mo., so I wouldn't recommend running it long-term.
+Running this on the west coast runs >$50 / mo., so I wouldn't recommend running it long-term.
 The only reason I'm using AWS at the moment is to quickly iterate on designs that I actually plan on deploying bare metal.
 The platform is very nice and feature-rich, but prohibitively expensive for home projects.
 

--- a/infra/appliance/variables.tf
+++ b/infra/appliance/variables.tf
@@ -7,9 +7,9 @@ variable "instance_ami" {type = string}
 variable "instance_type" {
     type = string
     # even this might be more than we need
-    # as of this writing it's 0.0104 / hr in oregon and a couple other regions
-    # so, average of $7.5972 / month / appliance
-    default = "t3.micro"
+    # as of 2022-7-1 the t4g.nano is $0.0042 / hr in oregon
+    # so, average of $3.066 / month
+    default = "t4g.nano"
 }
 # value in GiB, as in aws_instance
 variable "volume_size" {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -23,7 +23,7 @@ data "aws_ami" "main" {
 
   filter {
     name   = "architecture"
-    values = ["x86_64"]
+    values = ["arm64"]
   }
 
   filter {

--- a/infra/monitor.tf
+++ b/infra/monitor.tf
@@ -6,8 +6,10 @@ module "appliance_monitor" {
     name = "monitor"
     source = "./appliance"
     # limiting factor here is definitely main memory.
-    # Running on a t3a.small, with 2 GiB, you run out before you've even installed all the components.
-    instance_type = "t3a.medium"
+    # Running on a small with only 2 GiB you run out before you've even installed all the components.
+    # as of 2022-7-1 the t4g.medium is $0.0336 / hr in oregon
+    # so, average of $24.528 / month
+    instance_type = "t4g.medium"
     volume_size = 12 # GiB
     vpc_name = var.vpc_name
     key_name = aws_key_pair.ssh.key_name


### PR DESCRIPTION
The instances were previously `t3.micro` and `t3a.medium`. Trying to cut some costs, so downgrading to `t4g.nano` and `t4g.medium`. However, `t4g` is on `arm64`, while `t3[a]` is on `x86_64` (`amd64`). So I switched out the architecture, and validated that the `monitor` ansible still works fine.

It does. Expected, since ELK stack is on Java and `openjdk-17` runs on both arches.